### PR TITLE
Address to Google Maps Link (Issue H4ISH-6)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import logo from './logo.svg';
 import './App.css';
 
-function App() {
+function App(): JSX.Element {
   return (
     <div className="App">
       <header className="App-header">

--- a/src/helpers/MapLinkFromAddress.ts
+++ b/src/helpers/MapLinkFromAddress.ts
@@ -1,0 +1,17 @@
+/**
+ * Returns the Google Maps URL for the Address or Name
+ * @param address The address or name to find
+ * @returns the url of the address on google maps
+ */
+export default function MapLinkFromAddress(address: string): string {
+  if (!address || !address.trim()) {
+    throw new Error('Empty Parameter address');
+  }
+
+  const GoogleMapsBaseURL = 'https://www.google.com/maps/search/?api=1&';
+
+  // Changes space to '+' and commas to '%2C'
+  const changedAddress = address.replace(/ /g, '+').replace(',', '%2C');
+
+  return `${GoogleMapsBaseURL}query=${changedAddress}`;
+}

--- a/src/helpers/helpers.test.ts
+++ b/src/helpers/helpers.test.ts
@@ -1,0 +1,40 @@
+import AddressToLink from 'src/helpers/MapLinkFromAddress';
+
+describe('Address string to Google Maps URL Empty Cases', () => {
+  test('Fail on Empty/Whitespace String', () => {
+    expect(() => AddressToLink('')).toThrowError('Empty Parameter address');
+    expect(() => AddressToLink('  ')).toThrowError('Empty Parameter address');
+    expect(() => AddressToLink('test string')).not.toThrow();
+  });
+
+  test('Generates Nonempty URL', () => {
+    expect(AddressToLink('test string')).toBeTruthy();
+    expect(AddressToLink('1600 Pennsylvania Avenue NW, Washington, DC 20500')).toBeTruthy();
+    expect(AddressToLink('Knoxville, TN 37996')).toBeTruthy();
+  });
+});
+
+describe('Address string to Google Maps URL Correct Responses', () => {
+  test('Simple Sample Address', () => {
+    expect(AddressToLink('201 3rd Avenue Knoxville, TN 37917')).toBe(
+      'https://www.google.com/maps/search/?api=1&query=201+3rd+Avenue+Knoxville%2C+TN+37917'
+    );
+    expect(AddressToLink('8729 Chapman Highway Knoxville, TN 37920')).toBe(
+      'https://www.google.com/maps/search/?api=1&query=8729+Chapman+Highway+Knoxville%2C+TN+37920'
+    );
+    expect(AddressToLink('62 Ridgeway Road Norris, TN 37828')).toBe(
+      'https://www.google.com/maps/search/?api=1&query=62+Ridgeway+Road+Norris%2C+TN+37828'
+    );
+  });
+  test('Just Name of Location', () => {
+    expect(AddressToLink('C.A.R.E. Food Pantry')).toBe(
+      'https://www.google.com/maps/search/?api=1&query=C.A.R.E.+Food+Pantry'
+    );
+    expect(AddressToLink('Hines Creek Baptist Church')).toBe(
+      'https://www.google.com/maps/search/?api=1&query=Hines+Creek+Baptist+Church'
+    );
+    expect(AddressToLink('Reaching the Needy Food Pantry')).toBe(
+      'https://www.google.com/maps/search/?api=1&query=Reaching+the+Needy+Food+Pantry'
+    );
+  });
+});

--- a/src/reportWebVitals.ts
+++ b/src/reportWebVitals.ts
@@ -1,6 +1,6 @@
 import { ReportHandler } from 'web-vitals';
 
-const reportWebVitals = (onPerfEntry?: ReportHandler) => {
+const reportWebVitals = (onPerfEntry?: ReportHandler): void => {
   if (onPerfEntry && onPerfEntry instanceof Function) {
     import('web-vitals').then(({ getCLS, getFID, getFCP, getLCP, getTTFB }) => {
       getCLS(onPerfEntry);


### PR DESCRIPTION
Address to Google Maps Link
---

### Changes
- Added function to convert any string representation of an address to the link that would send a user to a google maps pin of that address
    - If the address is just the name of the location (or pantry) that works as well
    - Implementation changes commas to `%2C` and space characters with `+`
- Tests were also added to test empty cases and validate correct return values

### Fixes
- Modified some of the boilerplate code to remove linter errors (2 no return type on function errors)

### Functions
```typescript
// src/helpers/MapLinkFromAddress.ts
/** 
 * Returns the Google Maps URL for the Address or Name
 * @param address The address or name to find
 * @returns the url of the address on google map
 */
export default function MapLinkFromAddress(address: string): string
```