### PR TITLE
Pantry Search and Suggestions Fixes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,7 +14,9 @@ function App(): JSX.Element {
   useEffect(() => {
     const gatherData = async () => {
       try {
-        setFoodPantries(await getFoodPantries());
+        const allPantries = await getFoodPantries();
+        setFoodPantries(allPantries);
+        setFilteredPantries(allPantries);
       } catch (e) {
         // eslint-disable-next-line no-console
         console.log(`Error: ${e}`);

--- a/src/components/FoodPantryCard/index.tsx
+++ b/src/components/FoodPantryCard/index.tsx
@@ -2,6 +2,7 @@ import '../../styles/main.css';
 import React, { FunctionComponent } from 'react';
 import { FoodPantry } from 'src/utils/types';
 import './pantryCard.css';
+import MapLinkFromAddress from 'src/helpers/MapLinkFromAddress';
 
 interface Props {
   pantry: FoodPantry;
@@ -94,9 +95,11 @@ const FoodPantryCard: FunctionComponent<Props> = ({ pantry }) => {
         )}
       </div>
 
-      <button type="button" className="get_directions">
-        Get Directions
-      </button>
+      <a target="_blank" rel="noopener noreferrer" href={MapLinkFromAddress(pantry.address)}>
+        <button type="button" className="get_directions">
+          Get Directions
+        </button>
+      </a>
     </div>
   );
 };

--- a/src/components/SearchButton/index.tsx
+++ b/src/components/SearchButton/index.tsx
@@ -16,8 +16,9 @@ interface Props {
 
 // Helper Function
 const isInString = (str: string, text: string): boolean => {
-  const safeText = text.replace(/\W/g, '').toLowerCase();
-  return str.toLowerCase().search(safeText) !== -1;
+  console.log(`Comparing ${text.toLowerCase()} and ${str.toLowerCase()}`);
+  const safeText = text.toLowerCase();
+  return str.toLowerCase().includes(safeText);
 };
 
 // Type Guard for Food Pantries
@@ -33,14 +34,14 @@ const SearchButton: FunctionComponent<Props> = ({ pantries, setFilteredPantries 
 
   const getSuggestions = (searchQuery: string | undefined, counties: string[]): Suggestion[] => {
     if (!searchQuery || searchQuery.length < 3) return [];
-    const query = searchQuery.toLowerCase().replace(/\W/g, '');
-    const CountyMatches = counties.filter(countyName => countyName.toLowerCase().search(query) !== -1);
+    const query = searchQuery.toLowerCase();
+    const CountyMatches = counties.filter(countyName => countyName.toLowerCase().includes(query));
 
     const PantryMatches: FoodPantry[] = pantries.filter(
       pantry =>
-        pantry.name.toLowerCase().search(query) !== -1 ||
-        pantry.address.toLowerCase().search(query) !== -1 ||
-        pantry.county.toLowerCase().search(query) !== -1
+        pantry.name.toLowerCase().includes(query) ||
+        pantry.address.toLowerCase().includes(query) ||
+        pantry.county.toLowerCase().includes(query)
     );
 
     return [...CountyMatches.map(match => `${match} County`), ...PantryMatches].splice(0, 5);
@@ -151,9 +152,10 @@ const SearchButton: FunctionComponent<Props> = ({ pantries, setFilteredPantries 
               setFilteredPantries(textFilterPantries(searchInput || ''));
               setSuggestions([]);
             }
-            if (usingCurrLoc && e.key === 'Backspace') {
+            if ((usingCurrLoc || searchInput === '') && e.key === 'Backspace') {
               setSearchInput('');
               setUsingCurrLoc(false);
+              setFilteredPantries(pantries);
             }
           }}
         />
@@ -165,7 +167,14 @@ const SearchButton: FunctionComponent<Props> = ({ pantries, setFilteredPantries 
                 className="Suggestions-Area"
                 key={isFoodPantry(suggest) ? suggest.name : suggest}
                 type="button"
-                onClick={() => {}}>
+                onClick={() => {
+                  const nameToSearch = isFoodPantry(suggest) ? suggest.name : suggest.replace(' County', '');
+                  console.log(nameToSearch);
+                  const pantriesFiltered = textFilterPantries(nameToSearch);
+                  setFilteredPantries(pantriesFiltered);
+                  setSearchInput(isFoodPantry(suggest) ? suggest.name : suggest);
+                  setSuggestions([]);
+                }}>
                 {isFoodPantry(suggest) ? (
                   <svg
                     className="SuggestionsPin"

--- a/src/components/SearchButton/index.tsx
+++ b/src/components/SearchButton/index.tsx
@@ -149,6 +149,7 @@ const SearchButton: FunctionComponent<Props> = ({ pantries, setFilteredPantries 
           onKeyDown={e => {
             if (e.key === 'Enter') {
               setFilteredPantries(textFilterPantries(searchInput || ''));
+              setSuggestions([]);
             }
             if (usingCurrLoc && e.key === 'Backspace') {
               setSearchInput('');


### PR DESCRIPTION
# Changes
---
- Made all cards show on initial load
- Clear Suggestions when user hits enter on search
- changed all `search` on strings to `includes` for readability and so we do not need to parse string for regex chars
- Suggestions are now clickable
- Get Directions button now opens Google Maps to pantry in other tab